### PR TITLE
Fix parsing array object to json issue.

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="e-goi-wrappers" default="dist">
-	<property name="app.main.version" value="0.3.6.10"/>
+	<property name="app.main.version" value="0.3.6.11"/>
 
 	<property name="e-goi-wrapper-asp.version" value="${app.main.version}" />
 	<property name="e-goi-wrapper-cpp.version" value="${app.main.version}" />

--- a/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/EgoiApi.csproj
+++ b/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/EgoiApi.csproj
@@ -31,9 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\Dependencies\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Extensions" />

--- a/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/EgoiMap.cs
+++ b/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/EgoiMap.cs
@@ -31,7 +31,15 @@ namespace Egoi
             {
                 if (idx++ > 0)
                     s.Append(", ");
-                s.Append("\"").Append(k).Append("\"").Append(":").Append("\"").Append(this[k]).Append("\"");
+                s.Append("\"").Append(k).Append("\"").Append(":");
+
+                if ((this[k] is string))
+                    s.Append("\"");
+
+                s.Append(this[k]);
+
+                if ((this[k] is string))
+                    s.Append("\"");
             }
             s.Append("}");
             return s.ToString();

--- a/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiApiRestImpl.cs
+++ b/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiApiRestImpl.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiResellersRestImpl.cs
+++ b/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiResellersRestImpl.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiSlingshotRestImpl.cs
+++ b/e-goi-wrapper-csharp/EgoiApiProject/EgoiApi/Impl/Rest/EgoiSlingshotRestImpl.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
when parsing array objects to json the generated string put commas ("") on json arrays...

**Before**
"TAGS":**"[**{"value":"4"}, {"value":"5"}**]"**

**After**
"TAGS":**[**{"value":"4"}, {"value":"5"}**]**
